### PR TITLE
Eliminar Categorias

### DIFF
--- a/front-inventory/src/app/modules/category/components/category/category.component.html
+++ b/front-inventory/src/app/modules/category/components/category/category.component.html
@@ -50,7 +50,7 @@
             <mat-icon aria-label="Edit">edit</mat-icon>
           </button>
 
-          <button mat-icon-button color="warn">
+          <button mat-icon-button color="warn" (click)="delete(element.id)">
             <mat-icon aria-label="Delete">delete</mat-icon>
           </button>
 

--- a/front-inventory/src/app/modules/category/components/category/category.component.ts
+++ b/front-inventory/src/app/modules/category/components/category/category.component.ts
@@ -4,6 +4,7 @@ import {MatTableDataSource} from "@angular/material/table";
 import {MatDialog} from "@angular/material/dialog";
 import {NewCategoryComponent} from "../new-category/new-category.component";
 import {MatSnackBar, MatSnackBarRef, SimpleSnackBar} from "@angular/material/snack-bar";
+import {ConfirmComponent} from "../../../shared/components/confirm/confirm.component";
 
 @Component({
   selector: 'app-category',
@@ -85,6 +86,24 @@ export class CategoryComponent implements OnInit {
 
     });
 
+  }
+
+  delete(id: any){
+
+    const dialogRef = this.dialog.open(ConfirmComponent, {
+
+      data: {id:id}
+    });
+
+    dialogRef.afterClosed().subscribe((result: any) => {
+      if (result == 1) {
+        this.openSnackBar("categoría Eliminada","Exitosa");
+        this.getCategories();
+      } else if (result == 2) {
+        this.openSnackBar("Se produjo un error al eliminar categoría","Error");
+      }
+
+    });
   }
 
 

--- a/front-inventory/src/app/modules/shared/components/confirm/confirm.component.html
+++ b/front-inventory/src/app/modules/shared/components/confirm/confirm.component.html
@@ -1,0 +1,9 @@
+<h1 mat-dialog-title>Confirmación </h1>
+<div mat-dialog-content>
+  <p>¿Estás seguro de eliminar el registro?</p>
+  <div mat-dialog-actions>
+        <button mat-button (click)="onNoClick()">No</button>
+        <button mat-button (click)="delete()" cdkFocusInitial>Si</button>
+  </div>
+
+</div>

--- a/front-inventory/src/app/modules/shared/components/confirm/confirm.component.spec.ts
+++ b/front-inventory/src/app/modules/shared/components/confirm/confirm.component.spec.ts
@@ -1,0 +1,21 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { ConfirmComponent } from './confirm.component';
+
+describe('ConfirmComponent', () => {
+  let component: ConfirmComponent;
+  let fixture: ComponentFixture<ConfirmComponent>;
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      declarations: [ConfirmComponent]
+    });
+    fixture = TestBed.createComponent(ConfirmComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/front-inventory/src/app/modules/shared/components/confirm/confirm.component.ts
+++ b/front-inventory/src/app/modules/shared/components/confirm/confirm.component.ts
@@ -1,0 +1,43 @@
+import {Component, OnInit} from '@angular/core';
+import {CategoryService} from "../../services/category.service";
+import {inject} from "@angular/core";
+import {MAT_DIALOG_DATA, MatDialogRef} from "@angular/material/dialog";
+import {subscribeOn} from "rxjs";
+
+@Component({
+  selector: 'app-confirm',
+  templateUrl: './confirm.component.html',
+  styleUrls: ['./confirm.component.css']
+})
+export class ConfirmComponent  implements  OnInit{
+
+     private categoryService = inject(CategoryService);
+     private dialogRef = inject(MatDialogRef);
+     public data = inject(MAT_DIALOG_DATA);
+
+
+    ngOnInit(): void {
+        throw new Error('Method not implemented.');
+    }
+
+  onNoClick(){
+      this.dialogRef.close(3);
+  }
+
+  delete(){
+    if(this.data != null){
+      this.categoryService.deleteCategorie(this.data.id)
+        .subscribe((data:any)=>{
+          this.dialogRef.close(1);
+      }, (error: any) => {
+          this.dialogRef.close(2);
+        })
+    }else {
+      this.dialogRef.close(2);
+    }
+  }
+
+
+
+
+}

--- a/front-inventory/src/app/modules/shared/services/category.service.ts
+++ b/front-inventory/src/app/modules/shared/services/category.service.ts
@@ -36,6 +36,14 @@ export class CategoryService {
     return this.http.put(endpoint, body);
   }
 
+  /**
+   * delete categorie
+   */
+  deleteCategorie(id: any){
+    const endpoint = `${base_url}/categories/${id}`;
+    return this.http.delete(endpoint);
+  }
+
 
 
 }

--- a/front-inventory/src/app/modules/shared/shared.module.ts
+++ b/front-inventory/src/app/modules/shared/shared.module.ts
@@ -4,12 +4,14 @@ import { SidenavComponent } from './components/sidenav/sidenav.component';
 import {MaterialModule} from "./material.module";
 import {RouterModule} from "@angular/router";
 import {HttpClientModule} from "@angular/common/http";
+import { ConfirmComponent } from './components/confirm/confirm.component';
 
 
 
 @NgModule({
   declarations: [
-    SidenavComponent
+    SidenavComponent,
+    ConfirmComponent
   ],
   exports: [
     SidenavComponent


### PR DESCRIPTION
Este Pull Request  elimina las categorías obsoletas que ya no están en uso dentro de la funcionalidad de productos. Anteriormente, las categorías de producto no eran relevantes debido a una actualización del flujo de negocio, y ahora se remueven del sistema para simplificar la base de datos y reducir la complejdidad en la UI.

**Cambios realizados:**

- Eliminación de la tabla `categories` de la base de datos
- Remoción de la relación entre productos y categorías en el modelo de datos.
- Ajuste de los controladores y servicios para no tener en cuenta las categorías.
- Modificación del frontend para remover las referencias a las categorías en la vista de productos.

